### PR TITLE
Make qwerty map behave like sample layout

### DIFF
--- a/keyboard/atreus/keymap_common.h
+++ b/keyboard/atreus/keymap_common.h
@@ -59,19 +59,35 @@ extern const uint16_t fn_actions[];
                           KC_FN1, SHIFT(KC_INS), KC_LGUI, KC_LSFT, KC_BSPC, KC_LCTL, KC_LALT, \
                             KC_SPC, KC_FN0, KC_DOT, KC_0, KC_EQUAL)
 
-#define FN_ARROW_LAYER   KEYMAP(SHIFT(KC_1), SHIFT(KC_2), KC_UP, SHIFT(KC_MINS), SHIFT(KC_EQUAL), \
+/*
+ *  !    @     up     {    }        ||     pgup    7     8     9    *
+ *  #  left   down  right  $        ||     pgdn    4     5     6    +
+ *  [    ]      (     )    &        ||       `     1     2     3    \
+ * L2  insert super shift bksp ctrl || alt space   fn    .     0    =
+ */
+#define FN_ARROW_LAYER   KEYMAP(SHIFT(KC_1), SHIFT(KC_2), KC_UP, SHIFT(KC_LBRC), SHIFT(KC_RBRC), \
                                   KC_PGUP, KC_7, KC_8, KC_9, SHIFT(KC_8), \
                                 SHIFT(KC_3), KC_LEFT, KC_DOWN, KC_RIGHT, SHIFT(KC_4), \
-                                  KC_PGDN, KC_4, KC_5, KC_6, SHIFT(KC_RBRC), \
-                                KC_MINS, KC_EQUAL, SHIFT(KC_9), SHIFT(KC_0), SHIFT(KC_7), \
+                                  KC_PGDN, KC_4, KC_5, KC_6, SHIFT(KC_EQUAL), \
+                                KC_LBRC, KC_RBRC, SHIFT(KC_9), SHIFT(KC_0), SHIFT(KC_7), \
                                   KC_GRAVE, KC_1, KC_2, KC_3, KC_BSLS,    \
-                                KC_FN1, SHIFT(KC_INS), KC_LGUI, KC_FN4, KC_BSPC, KC_LCTL, KC_LALT, \
-                                  KC_SPC, KC_FN0, KC_E, KC_0, KC_RBRC)
+                                KC_FN1, SHIFT(KC_INS), KC_LGUI, KC_FN4, KC_BSPC, KC_LCTL, \
+                                  KC_LALT, KC_SPC, KC_FN0, KC_E, KC_0, KC_EQUAL)
 
-#define LAYER_TWO KEYMAP(KC_INS, KC_HOME, KC_UP, KC_END, KC_PGUP, KC_UP, KC_F7, KC_F8, KC_F9, KC_F10, \
-                         KC_DEL, KC_LEFT, KC_DOWN, KC_RIGHT, KC_PGDN, KC_DOWN, KC_F4, KC_F5, KC_F6, KC_F11, \
-                         KC_NO, KC__VOLUP, KC_NO, KC_NO, KC_FN3, KC_NO, KC_F1, KC_F2, KC_F3, KC_F12, \
-                         KC_NO, KC__VOLDOWN, KC_LGUI, KC_LSFT, KC_BSPC, KC_LCTL, KC_LALT, KC_SPC, KC_FN2, KC_PSCREEN, KC_SLCK, KC_PAUSE)
+/*
+ * insert home   up  end   pgup       ||      up     F7    F8    F9   F10
+ *  del   left  down right pgdn       ||     down    F4    F5    F6   F11
+ *       volup             reset      ||             F1    F2    F3   F12
+ *       voldn  super shift bksp ctrl || alt space   L0  prtsc scroll pause
+ */
+#define LAYER_TWO KEYMAP(KC_INS, KC_HOME, KC_UP, KC_END, KC_PGUP, \
+                         KC_UP, KC_F7, KC_F8, KC_F9, KC_F10, \
+                         KC_DEL, KC_LEFT, KC_DOWN, KC_RIGHT, KC_PGDN, \
+                         KC_DOWN, KC_F4, KC_F5, KC_F6, KC_F11,          \
+                         KC_NO, KC__VOLUP, KC_NO, KC_NO, KC_FN3, \
+                         KC_NO, KC_F1, KC_F2, KC_F3, KC_F12,            \
+                         KC_NO, KC__VOLDOWN, KC_LGUI, KC_LSFT, KC_BSPC, KC_LCTL, \
+                         KC_LALT, KC_SPC, KC_FN2, KC_PSCREEN, KC_SLCK, KC_PAUSE)
 
 enum function_id {
   BOOTLOADER,


### PR DESCRIPTION
The layout described in the readme didn't match with the common
header.

Having the arrows handily available is pretty great.