### PR TITLE
PCB flipping code didn't actually flip the keys.

### DIFF
--- a/keyboard/atreus/keymap_common.h
+++ b/keyboard/atreus/keymap_common.h
@@ -44,10 +44,10 @@ extern const uint16_t fn_actions[];
   K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, \
   K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A \
 ) {                                                                     \
-  { K00, K01, K02, K03, K04, KC_NO, K05, K06, K07, K08, K09 }, \
-  { K10, K11, K12, K13, K14, KC_NO, K15, K16, K17, K18, K19 }, \
-  { K20, K21, K22, K23, K24, K35,   K25, K26, K27, K28, K29 }, \
-  { K2A, K30, K31, K32, K33, K34,   K36, K37, K38, K39, K3A } \
+  { K09, K08, K07, K06, K05, KC_NO, K04, K03, K02, K01, K00 }, \
+  { K19, K18, K17, K16, K15, KC_NO, K14, K13, K12, K11, K10 }, \
+  { K29, K28, K27, K26, K25, K35,   K24, K23, K22, K21, K20 }, \
+  { K3A, K39, K38, K37, K36, K34,   K33, K32, K31, K30, K2A } \
 }
 
 #define KEYMAP_PCBUP( \

--- a/keyboard/atreus/keymap_mine.c
+++ b/keyboard/atreus/keymap_mine.c
@@ -9,9 +9,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* 0: mostly letters */
   KEYMAP(KC_Q, KC_W, KC_E, KC_R, KC_T,         KC_Y, KC_U, KC_I,    KC_O,   KC_P, \
          KC_A, KC_S, KC_D, KC_F, KC_G,         KC_H, KC_J, KC_K,    KC_L,   KC_SCLN, \
-         KC_Z, KC_X, KC_C, KC_V, KC_B,         KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, \
-         KC_FN4, KC_TAB, KC_LGUI, KC_LALT, KC_BSPC, KC_LCTL, \
-                                     KC_LGUI,  KC_SPC, KC_FN0, KC_MINS, KC_QUOT, KC_FN5), \
+         KC_FN5, KC_X, KC_C, KC_V, KC_B,         KC_N, KC_M, KC_COMM, KC_DOT, KC_FN4, \
+         KC_ESC, KC_TAB, KC_LGUI, KC_LALT, KC_BSPC, KC_LCTL, \
+                                     KC_LGUI,  KC_SPC, KC_FN0, KC_MINS, KC_QUOT, KC_ENT), \
   /* 1: punctuation and numbers */
   FN_ARROW_LAYER,                                     \
   /* 2: arrows and function keys */
@@ -23,8 +23,8 @@ const uint16_t PROGMEM fn_actions[] = {
   [1] = ACTION_LAYER_ON(2, 1),  // switch to layer 2
   [2] = ACTION_LAYER_OFF(2, 1),  // switch back to layer 0
   [3] = ACTION_FUNCTION(BOOTLOADER),
-  [4] = ACTION_MODS_TAP_KEY(MOD_LSFT, KC_ESC),  // ESC key is LSHIFT when held down
-  [5] = ACTION_MODS_TAP_KEY(MOD_RSFT, KC_ENT)   // ENT key is RSHIFT when held down
+  [4] = ACTION_MODS_TAP_KEY(MOD_LSFT, KC_SLSH),  // / key is LSHIFT when held down
+  [5] = ACTION_MODS_TAP_KEY(MOD_RSFT, KC_Z)      // Z key is RSHIFT when held down
 };
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt)

--- a/keyboard/atreus/keymap_mine.c
+++ b/keyboard/atreus/keymap_mine.c
@@ -1,0 +1,35 @@
+#include "keymap_common.h"
+
+/* The default Atreus layout. First layer is normal keys, second
+   (momentary fn layer) is numbers, most punctuation, and
+   arrows. Third (modal, persistent) layer is function keys and other
+   rarely-used keys. */
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* 0: mostly letters */
+  KEYMAP(KC_Q, KC_W, KC_E, KC_R, KC_T,         KC_Y, KC_U, KC_I,    KC_O,   KC_P, \
+         KC_A, KC_S, KC_D, KC_F, KC_G,         KC_H, KC_J, KC_K,    KC_L,   KC_SCLN, \
+         KC_Z, KC_X, KC_C, KC_V, KC_B,         KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, \
+         KC_FN4, KC_TAB, KC_LGUI, KC_LALT, KC_BSPC, KC_LCTL, \
+                                     KC_LGUI,  KC_SPC, KC_FN0, KC_MINS, KC_QUOT, KC_FN5), \
+  /* 1: punctuation and numbers */
+  FN_ARROW_LAYER,                                     \
+  /* 2: arrows and function keys */
+  LAYER_TWO
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+  [0] = ACTION_LAYER_MOMENTARY(1),  // to Fn overlay
+  [1] = ACTION_LAYER_ON(2, 1),  // switch to layer 2
+  [2] = ACTION_LAYER_OFF(2, 1),  // switch back to layer 0
+  [3] = ACTION_FUNCTION(BOOTLOADER),
+  [4] = ACTION_MODS_TAP_KEY(MOD_LSFT, KC_ESC),  // ESC key is LSHIFT when held down
+  [5] = ACTION_MODS_TAP_KEY(MOD_RSFT, KC_ENT)   // ENT key is RSHIFT when held down
+};
+
+void action_function(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  if (id == BOOTLOADER) {
+    bootloader();
+  }
+}


### PR DESCRIPTION
I have an Atreus with the PCB  face down. (I can read the PCB through the bottom of my clear case.) The PCBDOWN macro seems to only flip the thumb keys, but the rest of them need to move Left-to-Right, too.

